### PR TITLE
Add upload error handling and spinner

### DIFF
--- a/simulator/forms.py
+++ b/simulator/forms.py
@@ -1,0 +1,38 @@
+from django import forms
+import os
+
+
+class ContextUploadForm(forms.Form):
+    """Form for uploading additional context files."""
+
+    file = forms.FileField()
+
+    ALLOWED_EXTENSIONS = {".txt", ".csv", ".pdf", ".docx"}
+
+    def clean_file(self):
+        uploaded = self.cleaned_data["file"]
+        ext = os.path.splitext(uploaded.name)[1].lower()
+        if ext not in self.ALLOWED_EXTENSIONS:
+            raise forms.ValidationError(
+                "Unsupported file type. Allowed: "
+                + ", ".join(sorted(self.ALLOWED_EXTENSIONS))
+            )
+        return uploaded
+
+
+class ExamUploadForm(forms.Form):
+    """Form for uploading an exam file."""
+
+    file = forms.FileField()
+
+    ALLOWED_EXTENSIONS = {".docx"}
+
+    def clean_file(self):
+        uploaded = self.cleaned_data["file"]
+        ext = os.path.splitext(uploaded.name)[1].lower()
+        if ext not in self.ALLOWED_EXTENSIONS:
+            raise forms.ValidationError(
+                "Unsupported file type. Allowed: "
+                + ", ".join(sorted(self.ALLOWED_EXTENSIONS))
+            )
+        return uploaded

--- a/simulator/static/simulator/style.css
+++ b/simulator/static/simulator/style.css
@@ -1,0 +1,153 @@
+body {
+    background: #18191a;
+    color: #f3f3f3;
+    font-family: 'Inter', sans-serif;
+    margin: 0;
+}
+
+.container {
+    max-width: 800px;
+    margin: 40px auto;
+    background: #232426;
+    border-radius: 18px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.3);
+    padding: 32px 36px 28px 36px;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 22px;
+}
+
+.session-badge {
+    background: #24292f;
+    color: #b9fbc0;
+    padding: 6px 16px;
+    border-radius: 18px;
+    font-size: 0.97em;
+    letter-spacing: 0.01em;
+}
+
+main {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 32px;
+}
+
+.file-upload h2 {
+    font-size: 1.14em;
+    margin-top: 0;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.icon {
+    font-size: 1.3em;
+    vertical-align: middle;
+}
+
+form {
+    margin-bottom: 10px;
+}
+
+.file-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.file-list li {
+    background: #222;
+    margin-bottom: 6px;
+    padding: 9px 14px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.file-list li.empty {
+    opacity: 0.7;
+    font-style: italic;
+    text-align: center;
+}
+
+.filename {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 220px;
+    display: inline-block;
+}
+
+.btn {
+    background: #24292f;
+    color: #b9fbc0;
+    border: none;
+    border-radius: 9px;
+    padding: 7px 16px;
+    cursor: pointer;
+    font-size: 1em;
+    transition: background 0.15s, color 0.15s, box-shadow 0.18s;
+}
+
+.btn.upload {
+    background: #2e6a90;
+    color: #fff;
+}
+
+.btn.remove {
+    background: #a33434;
+    color: #fff;
+    font-size: 1.12em;
+    padding: 6px 13px;
+}
+
+.btn.upload:hover, .btn.remove:hover {
+    filter: brightness(1.12);
+    box-shadow: 0 2px 8px rgba(80,150,255,0.11);
+}
+
+.btn.main-action {
+    margin-top: 32px;
+    width: 100%;
+    font-size: 1.13em;
+    padding: 14px 0;
+    background: linear-gradient(90deg,#3e618d,#a960ee);
+    color: #fff;
+    border-radius: 14px;
+    font-weight: 700;
+    box-shadow: 0 2px 16px rgba(100,30,240,0.08);
+}
+
+.btn.main-action:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+
+.spinner {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: #fff;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin-left: 8px;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+footer {
+    margin-top: 48px;
+}

--- a/simulator/templates/simulator/index.html
+++ b/simulator/templates/simulator/index.html
@@ -1,1 +1,84 @@
-<h1>Simulator Index</h1>
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Klausur-Simulator</title>
+    <link rel="stylesheet" href="{% static 'simulator/style.css' %}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Klausur-Simulator</h1>
+            <div class="session-badge">
+                <span>&#9679; Aktiv</span>
+            </div>
+        </header>
+        <main>
+            <section class="file-upload exam">
+                <h2><span class="icon">&#128196;</span> Klausur hochladen</h2>
+                <form action="{% url 'upload_exam' %}" method="post" enctype="multipart/form-data">
+                    {% csrf_token %}
+                    {{ exam_form.file }}
+                    {{ exam_form.file.errors }}
+                    <button class="btn upload" type="submit">Upload</button>
+                </form>
+                <ul class="file-list">
+                {% for f in exam_files %}
+                    <li>
+                        <span class="filename">{{ f.file.name|cut:"exam_files/" }}</span>
+                        <a class="btn remove" href="{% url 'delete_exam' f.pk %}" aria-label="Klausur entfernen">&#10006;</a>
+                    </li>
+                {% empty %}
+                    <li class="empty">Keine Klausur hochgeladen.</li>
+                {% endfor %}
+                </ul>
+            </section>
+
+            <section class="file-upload context">
+                <h2><span class="icon">&#128206;</span> Kontextdatei hochladen</h2>
+                <form action="{% url 'upload_context' %}" method="post" enctype="multipart/form-data">
+                    {% csrf_token %}
+                    {{ context_form.file }}
+                    {{ context_form.file.errors }}
+                    <button class="btn upload" type="submit">Upload</button>
+                </form>
+                <ul class="file-list">
+                {% for f in context_files %}
+                    <li>
+                        <span class="filename">{{ f.file.name|cut:"context_files/" }}</span>
+                        <a class="btn remove" href="{% url 'delete_context' f.pk %}" aria-label="Kontext entfernen">&#10006;</a>
+                    </li>
+                {% empty %}
+                    <li class="empty">Keine Kontextdateien hochgeladen.</li>
+                {% endfor %}
+                </ul>
+            </section>
+        </main>
+        <footer>
+            <button class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>
+        </footer>
+    </div>
+
+    <script>
+        const actionBtn = document.querySelector('.btn.main-action');
+        const hasExam = {{ exam_files|length }} > 0;
+        const hasContext = {{ context_files|length }} > 0;
+        if (hasExam && hasContext) {
+            actionBtn.removeAttribute('disabled');
+            actionBtn.removeAttribute('title');
+        }
+
+        actionBtn.addEventListener('click', () => {
+            if (actionBtn.disabled) return;
+            actionBtn.setAttribute('disabled', '');
+            const spinner = document.createElement('span');
+            spinner.className = 'spinner';
+            actionBtn.appendChild(spinner);
+        });
+    </script>
+</body>
+</html>

--- a/simulator/urls.py
+++ b/simulator/urls.py
@@ -3,4 +3,8 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('upload/context/', views.upload_context, name='upload_context'),
+    path('upload/exam/', views.upload_exam, name='upload_exam'),
+    path('delete/context/<int:pk>/', views.delete_context, name='delete_context'),
+    path('delete/exam/<int:pk>/', views.delete_exam, name='delete_exam'),
 ]

--- a/simulator/views.py
+++ b/simulator/views.py
@@ -1,6 +1,114 @@
-from django.shortcuts import render
+from __future__ import annotations
+
+import uuid
+
+from django.shortcuts import get_object_or_404, redirect, render
+
+from .forms import ContextUploadForm, ExamUploadForm
+from .models import ContextFile, ExamFile
+
+
+def _ensure_session_id(request) -> str:
+    """Return a session ID, creating one if needed."""
+    session_id = request.session.get("session_id")
+    if not session_id:
+        session_id = uuid.uuid4().hex
+        request.session["session_id"] = session_id
+    return session_id
 
 
 def index(request):
-    """Simple view rendering the simulator index page."""
-    return render(request, "simulator/index.html")
+    """Display upload forms and current session files."""
+    session_id = request.session.get("session_id")
+    context_files = (
+        ContextFile.objects.filter(session_id=session_id) if session_id else []
+    )
+    exam_files = ExamFile.objects.filter(session_id=session_id) if session_id else []
+    return render(
+        request,
+        "simulator/index.html",
+        {
+            "context_form": ContextUploadForm(),
+            "exam_form": ExamUploadForm(),
+            "context_files": context_files,
+            "exam_files": exam_files,
+            "session_id": session_id,
+        },
+    )
+
+
+def upload_context(request):
+    """Handle context file uploads."""
+    if request.method == "POST":
+        form = ContextUploadForm(request.POST, request.FILES)
+        if form.is_valid():
+            session_id = _ensure_session_id(request)
+            ContextFile.objects.create(
+                file=form.cleaned_data["file"], session_id=session_id
+            )
+            return redirect("index")
+        session_id = request.session.get("session_id")
+        context_files = (
+            ContextFile.objects.filter(session_id=session_id) if session_id else []
+        )
+        exam_files = ExamFile.objects.filter(session_id=session_id) if session_id else []
+        return render(
+            request,
+            "simulator/index.html",
+            {
+                "context_form": form,
+                "exam_form": ExamUploadForm(),
+                "context_files": context_files,
+                "exam_files": exam_files,
+                "session_id": session_id,
+            },
+        )
+    return redirect("index")
+
+
+def upload_exam(request):
+    """Handle exam file uploads."""
+    if request.method == "POST":
+        form = ExamUploadForm(request.POST, request.FILES)
+        if form.is_valid():
+            session_id = _ensure_session_id(request)
+            ExamFile.objects.filter(session_id=session_id).delete()
+            ExamFile.objects.create(
+                file=form.cleaned_data["file"], session_id=session_id
+            )
+            return redirect("index")
+        session_id = request.session.get("session_id")
+        context_files = (
+            ContextFile.objects.filter(session_id=session_id) if session_id else []
+        )
+        exam_files = ExamFile.objects.filter(session_id=session_id) if session_id else []
+        return render(
+            request,
+            "simulator/index.html",
+            {
+                "context_form": ContextUploadForm(),
+                "exam_form": form,
+                "context_files": context_files,
+                "exam_files": exam_files,
+                "session_id": session_id,
+            },
+        )
+    return redirect("index")
+
+
+def delete_context(request, pk: int):
+    """Remove a context file from the current session."""
+    session_id = request.session.get("session_id")
+    file_obj = get_object_or_404(ContextFile, pk=pk, session_id=session_id)
+    file_obj.file.delete(save=False)
+    file_obj.delete()
+    return redirect("index")
+
+
+def delete_exam(request, pk: int):
+    """Remove an exam file from the current session."""
+    session_id = request.session.get("session_id")
+    file_obj = get_object_or_404(ExamFile, pk=pk, session_id=session_id)
+    file_obj.file.delete(save=False)
+    file_obj.delete()
+    return redirect("index")


### PR DESCRIPTION
## Summary
- show form errors and add aria labels for removal buttons
- return to the index page with validation errors
- disable action button on click and show spinner

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_686ea96ed4b88324a9d84ec6c44cb07c