### PR TITLE
Improve AI result generation

### DIFF
--- a/KlaSim/settings.py
+++ b/KlaSim/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -122,3 +123,7 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# OpenAI configuration
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4-1106-preview")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ asgiref==3.9.1
 Django==4.2.23
 sqlparse==0.5.3
 typing_extensions==4.14.1
+python-docx==1.2.0
+openai==1.93.3
+PyPDF2==3.0.1

--- a/simulator/services.py
+++ b/simulator/services.py
@@ -1,0 +1,131 @@
+import os
+import csv
+from pathlib import Path
+from typing import List
+
+MAX_PROMPT_CHARS = 25000
+
+from django.conf import settings
+from django.core.files.base import File
+
+import openai
+from docx import Document
+from PyPDF2 import PdfReader
+
+from .models import AIResult, ContextFile, ExamFile
+
+
+LEVEL_INSTRUCTIONS = {
+    "low": (
+        "Bearbeite die Aufgabe so, als wärst du ein schwacher Schüler mit vielen Lücken "
+        "und Unsicherheiten. Mache typische Fehler, schreibe knapp oder lückenhaft, "
+        "beantworte nur das, was du sicher weißt. Antworte ggf. auch mit Falschantworten, "
+        "die im Kontext vorkommen könnten."
+    ),
+    "medium": (
+        "Bearbeite die Aufgabe als durchschnittlicher Schüler: gib solide, aber nicht "
+        "perfekte Antworten, manchmal fehlen Details oder es gibt kleinere Fehler."
+    ),
+    "high": (
+        "Bearbeite die Aufgabe als sehr guter Schüler: antworte vollständig, präzise "
+        "und mit korrekter Fachsprache. Gehe auch auf Details und Hintergründe ein, "
+        "sofern sie im Kontext stehen."
+    ),
+}
+
+BASE_INSTRUCTION = (
+    "Nutze ausschließlich die folgenden Kontextinformationen als Wissensquelle. "
+    "Beantworte die Klausuraufgabe so, wie es ein Schüler auf dem angegebenen Leistungsniveau tun würde. "
+    "Gib ausschließlich den Lösungstext, ohne Einleitung, Erklärung oder Wiederholung der Aufgabe. "
+    "Wenn dir Informationen fehlen, antworte wie ein Schüler, der das Thema nicht vollständig versteht. "
+    "Der Antwortstil soll dem einer echten Schülerklausur entsprechen: schreibe klar, aber nicht überperfekt. "
+    "Keine Kommentare, keine Meta-Texte. Die Antworten sollen sich sprachlich, inhaltlich und vom Stil an echten Schülerantworten orientieren. "
+    "Niemals den Aufgabenstellungstext wiederholen oder Zusammenfassungen geben."
+)
+
+
+def _read_file(path: str) -> str:
+    """Return text content from a file path."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".docx":
+        doc = Document(path)
+        return "\n".join(p.text for p in doc.paragraphs)
+    if ext == ".csv":
+        with open(path, newline="", encoding="utf-8", errors="ignore") as fh:
+            reader = csv.reader(fh)
+            return "\n".join(",".join(row) for row in reader)
+    if ext == ".pdf":
+        try:
+            with open(path, "rb") as fh:
+                reader = PdfReader(fh)
+                return "\n".join((page.extract_text() or "") for page in reader.pages)
+        except Exception:
+            return ""
+    # Fallback to plain text
+    with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+        return fh.read()
+
+
+def assemble_prompt(session_id: str) -> str:
+    """Create a base prompt from uploaded exam and context files."""
+    exam = ExamFile.objects.filter(session_id=session_id).first()
+    if not exam:
+        raise ValueError("No exam file uploaded")
+    context_files = ContextFile.objects.filter(session_id=session_id)
+
+    exam_text = _read_file(exam.file.path)
+    context_text = "\n\n".join(_read_file(c.file.path) for c in context_files)
+
+    prompt = f"Exam:\n{exam_text}\n\nAdditional context:\n{context_text}"
+    if len(prompt) > MAX_PROMPT_CHARS:
+        raise ValueError("Zu viele oder zu große Kontextdateien f\u00fcr die KI")
+    return prompt
+
+
+def generate_ai_results(session_id: str, *, api_key: str | None = None) -> List[AIResult]:
+    """Generate AI answers for all performance levels."""
+    base_prompt = assemble_prompt(session_id)
+    client = openai.OpenAI(api_key=api_key or os.environ.get("OPENAI_API_KEY"))
+
+    storage_root = getattr(settings, "MEDIA_ROOT", "")
+    session_dir = Path(storage_root) / "ai_results" / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+
+    # Remove old results for this session
+    for old in AIResult.objects.filter(session_id=session_id):
+        old.file.delete(save=False)
+        old.delete()
+
+    results: List[AIResult] = []
+    for level, instruction in LEVEL_INSTRUCTIONS.items():
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Du bist ein Sch\u00fcler, der eine Klausur schreibt. "
+                    "Alle Antworten sollen realistisch wirken und keine Einleitungen oder Kommentare enthalten. "
+                    "Die Antworten sollen sich sprachlich, inhaltlich und vom Stil an echten Sch\u00fclerantworten orientieren. "
+                    "Niemals den Aufgabenstellungstext wiederholen oder Zusammenfassungen geben."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"{base_prompt}\n\n{BASE_INSTRUCTION}\n{instruction}",
+            },
+        ]
+        model = getattr(settings, "OPENAI_MODEL", "gpt-4-1106-preview")
+        response = client.chat.completions.create(model=model, messages=messages)
+        answer = response.choices[0].message.content.strip()
+
+        doc = Document()
+        doc.add_paragraph(answer)
+        file_name = f"{level}.docx"
+        file_path = session_dir / file_name
+        doc.save(file_path)
+
+        result = AIResult(level=level, session_id=session_id)
+        with open(file_path, "rb") as fh:
+            result.file.save(f"ai_results/{session_id}/{file_name}", File(fh), save=True)
+        results.append(result)
+
+    return results

--- a/simulator/templates/simulator/index.html
+++ b/simulator/templates/simulator/index.html
@@ -17,6 +17,13 @@
                 <span>&#9679; Aktiv</span>
             </div>
         </header>
+        {% if messages %}
+        <ul class="messages">
+        {% for message in messages %}
+            <li class="{{ message.tags }}">{{ message }}</li>
+        {% endfor %}
+        </ul>
+        {% endif %}
         <main>
             <section class="file-upload exam">
                 <h2><span class="icon">&#128196;</span> Klausur hochladen</h2>
@@ -57,9 +64,25 @@
                 {% endfor %}
                 </ul>
             </section>
+
+            {% if ai_results %}
+            <section class="ai-results">
+                <h2><span class="icon">&#128196;</span> Ergebnisse</h2>
+                <ul class="file-list">
+                {% for r in ai_results %}
+                    <li>
+                        <a href="{{ r.file.url }}" download>{{ r.level }} Ergebnis</a>
+                    </li>
+                {% endfor %}
+                </ul>
+            </section>
+            {% endif %}
         </main>
         <footer>
-            <button class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>
+            <form action="{% url 'run_simulation' %}" method="post">
+                {% csrf_token %}
+                <button class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>
+            </form>
         </footer>
     </div>
 

--- a/simulator/urls.py
+++ b/simulator/urls.py
@@ -7,4 +7,5 @@ urlpatterns = [
     path('upload/exam/', views.upload_exam, name='upload_exam'),
     path('delete/context/<int:pk>/', views.delete_context, name='delete_context'),
     path('delete/exam/<int:pk>/', views.delete_exam, name='delete_exam'),
+    path('run/', views.run_simulation, name='run_simulation'),
 ]


### PR DESCRIPTION
## Summary
- support PDF parsing with PyPDF2 and CSV handling
- configure OpenAI model via settings
- refine prompting and error handling in service
- show AI results and messages on index page
- refine AI prompts and clean old results before new generation
- enforce prompt length limit and tweak system instructions

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_686eb42c82708324b45c62fefa629b32