### PR TITLE
Fix AI results download URLs

### DIFF
--- a/KlaSim/settings.py
+++ b/KlaSim/settings.py
@@ -118,6 +118,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field

--- a/KlaSim/urls.py
+++ b/KlaSim/urls.py
@@ -15,8 +15,13 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('simulator.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/simulator/services.py
+++ b/simulator/services.py
@@ -125,7 +125,7 @@ def generate_ai_results(session_id: str, *, api_key: str | None = None) -> List[
 
         result = AIResult(level=level, session_id=session_id)
         with open(file_path, "rb") as fh:
-            result.file.save(f"ai_results/{session_id}/{file_name}", File(fh), save=True)
+            result.file.save(f"{session_id}/{file_name}", File(fh), save=True)
         results.append(result)
 
     return results

--- a/simulator/templates/simulator/index.html
+++ b/simulator/templates/simulator/index.html
@@ -17,6 +17,7 @@
                 <span>&#9679; Aktiv</span>
             </div>
         </header>
+
         {% if messages %}
         <ul class="messages">
         {% for message in messages %}
@@ -24,6 +25,7 @@
         {% endfor %}
         </ul>
         {% endif %}
+
         <main>
             <section class="file-upload exam">
                 <h2><span class="icon">&#128196;</span> Klausur hochladen</h2>
@@ -79,28 +81,27 @@
             {% endif %}
         </main>
         <footer>
-            <form action="{% url 'run_simulation' %}" method="post">
+            <form id="runForm" action="{% url 'run_simulation' %}" method="post">
                 {% csrf_token %}
-                <button class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>
+                <button id="runBtn" class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>
             </form>
         </footer>
     </div>
 
     <script>
-        const actionBtn = document.querySelector('.btn.main-action');
+        const runForm = document.getElementById('runForm');
+        const runBtn = document.getElementById('runBtn');
         const hasExam = {{ exam_files|length }} > 0;
         const hasContext = {{ context_files|length }} > 0;
         if (hasExam && hasContext) {
-            actionBtn.removeAttribute('disabled');
-            actionBtn.removeAttribute('title');
+            runBtn.removeAttribute('disabled');
+            runBtn.removeAttribute('title');
         }
-
-        actionBtn.addEventListener('click', () => {
-            if (actionBtn.disabled) return;
-            actionBtn.setAttribute('disabled', '');
+        runForm?.addEventListener('submit', () => {
+            runBtn.setAttribute('disabled', '');
             const spinner = document.createElement('span');
             spinner.className = 'spinner';
-            actionBtn.appendChild(spinner);
+            runBtn.appendChild(spinner);
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- correct file save path for AI results
- configure MEDIA_URL and MEDIA_ROOT
- serve media files during development

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_686ec45256c08324941d50a034f306f7