### PR TITLE
UI improvements for settings and index page

### DIFF
--- a/config/templates/config/login.html
+++ b/config/templates/config/login.html
@@ -3,17 +3,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Admin Login</title>
+    <title>Unlock Settings</title>
     <link rel="stylesheet" href="{% static 'simulator/style.css' %}">
 </head>
 <body>
 <div class="container">
-    <h1>Admin Login</h1>
+    <h1>Enter Password to unlock Settings</h1>
     <form method="post">
         {% csrf_token %}
         {{ form.as_p }}
         {% if error %}<p class="error">{{ error }}</p>{% endif %}
-        <button class="btn main-action" type="submit">Login</button>
+        <button class="btn main-action" type="submit">Unlock</button>
     </form>
 </div>
 </body>

--- a/config/templates/config/settings.html
+++ b/config/templates/config/settings.html
@@ -10,7 +10,7 @@
 <div class="container">
     <header>
         <h1>Settings</h1>
-        <a class="btn" href="{% url 'logout' %}">Logout</a>
+        <a class="btn" href="{% url 'logout' %}">Close Settings</a>
         <a class="btn" href="{% url 'sessions' %}">Sessions</a>
     </header>
     {% if messages %}
@@ -22,7 +22,30 @@
     {% endif %}
     <form id="settingsForm" method="post">
         {% csrf_token %}
-        {{ form.as_p }}
+        <div>
+            <label for="id_openai_api_key">OpenAI API Key</label>
+            <span id="keyStatus" class="state-label">{% if key_valid %}Valid{% else %}Invalid{% endif %}</span><br>
+            {{ form.openai_api_key }}
+            <p class="description">Used to access the OpenAI API.</p>
+        </div>
+        <div>
+            {{ form.language.label_tag }}
+            {{ form.language }}
+        </div>
+        <div>
+            <label for="id_new_password">Set new Settings-Password</label>
+            {{ form.new_password }}
+        </div>
+        <div>
+            <label class="toggle-label" for="simPwToggle">Require Simulation Password</label>
+            <label class="switch">
+                <input type="checkbox" id="simPwToggle" {% if sim_pw_set %}checked{% endif %}>
+                <span class="slider"></span>
+            </label>
+            <span class="state-label" data-for="simPwToggle"></span><br>
+            {{ form.simulation_password }}
+            <p class="description">Protects against unwanted costs in public networks.</p>
+        </div>
         <fieldset>
             <legend>Prompts ({{ language }})</legend>
             <div>
@@ -56,7 +79,6 @@
                 {{ prompt_form.level_high_text }}
             </div>
         </fieldset>
-        <p>Key status: <span id="keyStatus">{% if key_valid %}Valid{% else %}Invalid{% endif %}</span></p>
         <button class="btn main-action" type="submit">Save</button>
     </form>
 </div>
@@ -111,6 +133,18 @@ function toggleFields() {
             update();
             chk.addEventListener('change', update);
         }
+    }
+
+    const simToggle = document.getElementById('simPwToggle');
+    const simField = document.getElementById('id_simulation_password');
+    const simLabel = document.querySelector('span.state-label[data-for="simPwToggle"]');
+    if (simToggle && simField) {
+        const updateSim = () => {
+            simField.disabled = !simToggle.checked;
+            if (simLabel) simLabel.textContent = simToggle.checked ? 'On' : 'Off';
+        };
+        updateSim();
+        simToggle.addEventListener('change', updateSim);
     }
 }
 

--- a/config/views.py
+++ b/config/views.py
@@ -116,6 +116,7 @@ def settings_view(request):
         "prompt_form": prompt_form,
         "key_valid": key_valid,
         "language": display_lang,
+        "sim_pw_set": bool(config.simulation_password_hash),
     }
     return render(request, "config/settings.html", context)
 

--- a/simulator/static/simulator/style.css
+++ b/simulator/static/simulator/style.css
@@ -16,7 +16,6 @@ body {
 
 header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     margin-bottom: 22px;
 }
@@ -28,6 +27,7 @@ header {
     font-size: 0.97em;
     letter-spacing: 0.01em;
     color: #b9fbc0;
+    margin-left: auto;
 }
 .status-indicator.warn { color: #ffd500; }
 .status-indicator.error { color: #ff6565; }
@@ -38,6 +38,10 @@ header {
     margin-left: 12px;
     text-decoration: none;
     font-size: 1.2em;
+}
+footer .settings-link {
+    margin-left: 0;
+    margin-right: 12px;
 }
 .settings-link:hover { color: #fff; }
 
@@ -123,6 +127,12 @@ textarea {
     margin-right: 6px;
     font-size: 0.9em;
     opacity: 0.8;
+}
+.description {
+    font-size: 0.85em;
+    opacity: 0.75;
+    margin-top: -6px;
+    margin-bottom: 12px;
 }
 
 .file-list {
@@ -222,4 +232,6 @@ textarea {
 
 footer {
     margin-top: 48px;
+    display: flex;
+    align-items: center;
 }

--- a/simulator/templates/simulator/index.html
+++ b/simulator/templates/simulator/index.html
@@ -23,7 +23,6 @@
                     &#9679; Aktiv
                 {% endif %}
             </div>
-            <a class="settings-link" href="{% url 'settings' %}" title="Settings">&#9881;</a>
         </header>
 
         {% if messages %}
@@ -89,6 +88,7 @@
             {% endif %}
         </main>
         <footer>
+            <a class="settings-link" href="{% url 'settings' %}" title="Settings">&#9881;</a>
             <form id="runForm" action="{% url 'run_simulation' %}" method="post">
                 {% csrf_token %}
                 <input type="hidden" name="sim_password" id="simPwField">


### PR DESCRIPTION
## Summary
- move settings link to footer and put status indicator top-right
- adjust CSS for new layout and add helper text styling
- refine settings page layout with clearer labels and simulation-password toggle
- update login page wording

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687011eb62608324a146078d2e33e10e