### PR TITLE
UI polish for simulator

### DIFF
--- a/config/templates/config/settings.html
+++ b/config/templates/config/settings.html
@@ -21,7 +21,7 @@
     {% endfor %}
     </ul>
     {% endif %}
-    <form id="settingsForm" method="post">
+    <form id="settingsForm" class="settings-grid" method="post">
         {% csrf_token %}
         <div>
             <label for="id_openai_api_key">OpenAI API Key</label>
@@ -34,8 +34,8 @@
             {{ form.language }}
         </div>
         <div>
-            <label for="id_new_password">Set new Settings-Password</label>
-            {{ form.new_password }}
+            <button type="button" id="newPwBtn" class="btn">Set new Settings-Password</button>
+            {{ form.new_password.as_widget(attrs={'style': 'display:none;'}) }}
         </div>
         <div>
             <label class="toggle-label" for="simPwToggle">Require Simulation Password</label>
@@ -44,8 +44,10 @@
                 <span class="slider"></span>
             </label>
             <span class="state-label" data-for="simPwToggle"></span><br>
-            {{ form.simulation_password }}
-            <p class="description">Protects against unwanted costs in public networks.</p>
+            <div id="simPwContainer"{% if not sim_pw_set %} style="display:none;"{% endif %}>
+                {{ form.simulation_password }}
+                <p class="description">Protects against unwanted costs in public networks.</p>
+            </div>
         </div>
         <fieldset>
             <legend>Prompts ({{ language }})</legend>
@@ -82,6 +84,19 @@
         </fieldset>
         <button class="btn main-action" type="submit">Save</button>
     </form>
+</div>
+
+<div id="pwModal" class="modal-backdrop">
+    <div class="modal">
+        <label for="pw1">New password</label>
+        <input type="password" id="pw1">
+        <label for="pw2">Confirm password</label>
+        <input type="password" id="pw2">
+        <div class="modal-actions">
+            <button type="button" id="pwCancel" class="btn remove">Cancel</button>
+            <button type="button" id="pwConfirm" class="btn main-action">Confirm</button>
+        </div>
+    </div>
 </div>
 <script>
 const form = document.getElementById('settingsForm');
@@ -138,11 +153,13 @@ function toggleFields() {
 
     const simToggle = document.getElementById('simPwToggle');
     const simField = document.getElementById('id_simulation_password');
+    const simContainer = document.getElementById('simPwContainer');
     const simLabel = document.querySelector('span.state-label[data-for="simPwToggle"]');
     if (simToggle && simField) {
         const updateSim = () => {
             simField.disabled = !simToggle.checked;
             if (simLabel) simLabel.textContent = simToggle.checked ? 'On' : 'Off';
+            if (simContainer) simContainer.style.display = simToggle.checked ? 'block' : 'none';
         };
         updateSim();
         simToggle.addEventListener('change', updateSim);
@@ -150,6 +167,34 @@ function toggleFields() {
 }
 
 toggleFields();
+
+const newPwBtn = document.getElementById('newPwBtn');
+const pwModal = document.getElementById('pwModal');
+const pwCancel = document.getElementById('pwCancel');
+const pwConfirm = document.getElementById('pwConfirm');
+const pw1 = document.getElementById('pw1');
+const pw2 = document.getElementById('pw2');
+const hiddenNewPw = document.getElementById('id_new_password');
+
+if (newPwBtn && pwModal) {
+    newPwBtn.addEventListener('click', () => {
+        pw1.value = '';
+        pw2.value = '';
+        pwModal.style.display = 'flex';
+        pw1.focus();
+    });
+    pwCancel.addEventListener('click', () => {
+        pwModal.style.display = 'none';
+    });
+    pwConfirm.addEventListener('click', () => {
+        if (pw1.value !== pw2.value) {
+            alert('Passwords do not match');
+            return;
+        }
+        hiddenNewPw.value = pw1.value;
+        pwModal.style.display = 'none';
+    });
+}
 </script>
 </body>
 </html>

--- a/simulator/static/simulator/style.css
+++ b/simulator/static/simulator/style.css
@@ -34,11 +34,13 @@ header {
 
 .status-indicator {
     background: #24292f;
-    padding: 6px 16px;
+    padding: 4px 12px;
     border-radius: 18px;
-    font-size: 0.9em;
+    font-size: 0.85em;
     letter-spacing: 0.01em;
     color: #b9fbc0;
+    margin-left: 6px;
+    vertical-align: middle;
 }
 .status-indicator.warn { color: #ffd500; }
 .status-indicator.error { color: #ff6565; }
@@ -49,10 +51,6 @@ header {
     margin-left: 12px;
     text-decoration: none;
     font-size: 1.2em;
-}
-footer .settings-link {
-    margin-left: 0;
-    margin-right: 12px;
 }
 .settings-link:hover { color: #fff; }
 
@@ -83,6 +81,24 @@ main {
 
 form {
     margin-bottom: 16px;
+}
+
+.settings-grid > div {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    align-items: center;
+    gap: 10px;
+}
+
+.settings-grid fieldset > div {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    align-items: center;
+    gap: 10px;
+}
+
+.settings-grid fieldset > div textarea {
+    grid-column: 1 / span 2;
 }
 
 input[type=text], input[type=password], select, textarea {
@@ -285,6 +301,28 @@ p.error {
 
 footer {
     margin-top: 48px;
-    display: flex;
+}
+
+.modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.6);
+    display: none;
     align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal {
+    background: var(--panel-color);
+    padding: 20px;
+    border-radius: 12px;
+    width: 300px;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 16px;
 }

--- a/simulator/templates/simulator/index.html
+++ b/simulator/templates/simulator/index.html
@@ -10,17 +10,18 @@
 <body>
     <div class="container">
         <header>
-            <h1>Klausur-Simulator</h1>
-            <div class="status-indicator
-                {% if setup_required %} warn{% elif not api_key_valid %} error{% else %} ok{% endif %}">
-                {% if setup_required %}
-                    <a href="{% url 'setup' %}">Setup</a>
-                {% elif not api_key_valid %}
-                    &#9679; Key Fail
-                {% else %}
-                    &#9679; Aktiv
-                {% endif %}
-            </div>
+            <h1>Klausur-Simulator
+                <span class="status-indicator{% if setup_required %} warn{% elif not api_key_valid %} error{% else %} ok{% endif %}">
+                    {% if setup_required %}
+                        <a href="{% url 'setup' %}">Setup</a>
+                    {% elif not api_key_valid %}
+                        &#9679; Key Fail
+                    {% else %}
+                        &#9679; Aktiv
+                    {% endif %}
+                </span>
+            </h1>
+            <a class="settings-link" href="{% url 'settings' %}" title="Settings">&#9881;</a>
         </header>
 
         {% if messages %}
@@ -86,8 +87,7 @@
             {% endif %}
         </main>
         <footer>
-            <a class="settings-link" href="{% url 'settings' %}" title="Settings">&#9881;</a>
-            <form id="runForm" action="{% url 'run_simulation' %}" method="post">
+            <form id="runForm" action="{% url 'run_simulation' %}" method="post" style="width:100%;">
                 {% csrf_token %}
                 <input type="hidden" name="sim_password" id="simPwField">
                 <button id="runBtn" class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>


### PR DESCRIPTION
## Summary
- move settings icon to header and expand main action button
- hide simulation password field until required
- add modal for setting admin password
- add CSS grid styles and modal styling

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687021fea9cc832481d5a424281052a9