### PR TITLE
Fix hidden password field on settings page

### DIFF
--- a/config/forms.py
+++ b/config/forms.py
@@ -27,7 +27,10 @@ class LoginForm(forms.Form):
 
 
 class SettingsForm(forms.ModelForm):
-    new_password = forms.CharField(widget=forms.PasswordInput, required=False)
+    new_password = forms.CharField(
+        widget=forms.PasswordInput(attrs={"style": "display:none;"}),
+        required=False,
+    )
     simulation_password = forms.CharField(widget=forms.PasswordInput, required=False)
 
     class Meta:

--- a/config/templates/config/settings.html
+++ b/config/templates/config/settings.html
@@ -35,7 +35,7 @@
         </div>
         <div>
             <button type="button" id="newPwBtn" class="btn">Set new Settings-Password</button>
-            {{ form.new_password.as_widget(attrs={'style': 'display:none;'}) }}
+            {{ form.new_password }}
         </div>
         <div>
             <label class="toggle-label" for="simPwToggle">Require Simulation Password</label>


### PR DESCRIPTION
## Summary
- hide new password field via form widget attrs
- remove invalid template method call

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687025b835cc8324acc838097302d572