### PR TITLE
Improve settings layout

### DIFF
--- a/config/templates/config/settings.html
+++ b/config/templates/config/settings.html
@@ -33,7 +33,7 @@
             {{ form.language.label_tag }}
             {{ form.language }}
         </div>
-        <div>
+        <div class="single">
             <button type="button" id="newPwBtn" class="btn">Set new Settings-Password</button>
             {{ form.new_password }}
         </div>
@@ -82,7 +82,6 @@
                 {{ prompt_form.level_high_text }}
             </div>
         </fieldset>
-        <button class="btn main-action" type="submit">Save</button>
     </form>
 </div>
 
@@ -193,8 +192,16 @@ if (newPwBtn && pwModal) {
         }
         hiddenNewPw.value = pw1.value;
         pwModal.style.display = 'none';
+        form.requestSubmit();
     });
 }
+
+document.querySelectorAll('#settingsForm input, #settingsForm select, #settingsForm textarea')
+    .forEach(el => {
+        el.addEventListener('change', () => {
+            form.requestSubmit();
+        });
+    });
 </script>
 </body>
 </html>

--- a/simulator/static/simulator/style.css
+++ b/simulator/static/simulator/style.css
@@ -83,11 +83,28 @@ form {
     margin-bottom: 16px;
 }
 
+.settings-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+.settings-grid fieldset {
+    grid-column: 1 / -1;
+}
+
 .settings-grid > div {
     display: grid;
     grid-template-columns: 180px 1fr;
     align-items: center;
     gap: 10px;
+    border: 1px solid #444;
+    padding: 12px;
+    border-radius: 8px;
+}
+
+.settings-grid > div.single {
+    grid-template-columns: 1fr;
 }
 
 .settings-grid fieldset > div {
@@ -325,4 +342,8 @@ footer {
     justify-content: flex-end;
     gap: 10px;
     margin-top: 16px;
+}
+
+.modal-actions .btn {
+    flex: 1;
 }


### PR DESCRIPTION
## Summary
- improve layout of the settings form
- auto-submit settings form on change
- resize modal confirm buttons equally

## Testing
- `pytest -q`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687028b9effc83249810d4bc4b6eef14