### PR TITLE
Implement unified language control

### DIFF
--- a/config/templates/config/settings.html
+++ b/config/templates/config/settings.html
@@ -13,17 +13,6 @@
         <h1>{% trans "Settings" %}</h1>
         <a class="btn" href="{% url 'logout' %}">{% trans "Close Settings" %}</a>
         <a class="btn" href="{% url 'sessions' %}">{% trans "Sessions" %}</a>
-        <form action="{% url 'set_language' %}" method="post" style="display:inline-block;margin-left:1em;">
-            {% csrf_token %}
-            <select name="language" onchange="this.form.submit()">
-                {% get_current_language as LANGUAGE_CODE %}
-                {% get_available_languages as LANGUAGES %}
-                {% for lang in LANGUAGES %}
-                    <option value="{{ lang.0 }}" {% if lang.0 == LANGUAGE_CODE %}selected{% endif %}>{{ lang.1 }}</option>
-                {% endfor %}
-            </select>
-            <input type="hidden" name="next" value="{{ request.path }}?{{ request.GET.urlencode }}">
-        </form>
     </header>
     {% if messages %}
     <ul class="messages">

--- a/config/views.py
+++ b/config/views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.contrib import messages
 from django.core.management import call_command
 from django.http import HttpResponse
+from django.utils import translation
 import io
 import zipfile
 import openai
@@ -78,6 +79,8 @@ def login_view(request):
 def settings_view(request):
     config = AppConfig.get_solo()
     display_lang = request.GET.get("lang", config.language)
+    translation.activate(display_lang)
+    request.session[translation.LANGUAGE_SESSION_KEY] = display_lang
     prompts = {}
     for ptype in ["system", "base", "level_low", "level_medium", "level_high"]:
         pc = PromptConfig.objects.filter(language=display_lang, prompt_type=ptype).first()
@@ -94,6 +97,8 @@ def settings_view(request):
         if form.is_valid() and prompt_form.is_valid():
             form.save()
             display_lang = form.cleaned_data["language"]
+            translation.activate(display_lang)
+            request.session[translation.LANGUAGE_SESSION_KEY] = display_lang
             for ptype in ["system", "base", "level_low", "level_medium", "level_high"]:
                 pc, _ = PromptConfig.objects.get_or_create(language=display_lang, prompt_type=ptype)
                 use_custom = prompt_form.cleaned_data[f"{ptype}_custom"]


### PR DESCRIPTION
## Summary
- remove standalone language selector from settings header
- activate chosen language directly in `settings_view`
- store selected language in session when changed

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68704775618c83248e204d4ff2a433d0