### PR TITLE
Add translations for index and auth pages

### DIFF
--- a/config/templates/config/login.html
+++ b/config/templates/config/login.html
@@ -1,20 +1,20 @@
-{% load static %}
+{% load static i18n %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Unlock Settings</title>
+    <title>{% trans "Unlock Settings" %}</title>
     <link rel="stylesheet" href="{% static 'simulator/style.css' %}">
 </head>
 <body>
 <div class="container">
-    <h1>Enter Password to unlock Settings</h1>
+    <h1>{% trans "Enter password to unlock Settings" %}</h1>
     <form method="post">
         {% csrf_token %}
         {{ form.as_p }}
         {% if error %}<p class="error">{{ error }}</p>{% endif %}
-        <button class="btn main-action" type="submit">Unlock</button>
+        <button class="btn main-action" type="submit">{% trans "Unlock" %}</button>
     </form>
 </div>
 </body>

--- a/config/templates/config/sessions.html
+++ b/config/templates/config/sessions.html
@@ -1,17 +1,17 @@
-{% load static %}
+{% load static i18n %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Sessions</title>
+    <title>{% trans "Sessions" %}</title>
     <link rel="stylesheet" href="{% static 'simulator/style.css' %}">
 </head>
 <body>
 <div class="container">
     <header>
-        <h1>Sessions</h1>
-        <a class="btn" href="{% url 'settings' %}">Back</a>
+        <h1>{% trans "Sessions" %}</h1>
+        <a class="btn" href="{% url 'settings' %}">{% trans "Back" %}</a>
     </header>
     {% if messages %}
     <ul class="messages">
@@ -22,27 +22,27 @@
     {% endif %}
     <form method="post" action="{% url 'cleanup_sessions' %}" style="margin-bottom:20px;">
         {% csrf_token %}
-        <button class="btn remove" type="submit" onclick="return confirm('Delete all sessions?');">Delete All Sessions</button>
+        <button class="btn remove" type="submit" onclick="return confirm('{% trans "Delete all sessions?" %}');">{% trans "Delete All Sessions" %}</button>
     </form>
     <ul class="file-list">
     {% for s in sessions %}
         <li>
             <strong>{{ s.id }}</strong>
-            <a class="btn" href="{% url 'download_session_zip' s.id %}">Download ZIP</a>
+            <a class="btn" href="{% url 'download_session_zip' s.id %}">{% trans "Download ZIP" %}</a>
             <ul class="file-list" style="margin-top:10px;">
             {% for f in s.exam %}
-                <li><a href="{{ f.file.url }}" download>Exam</a></li>
+                <li><a href="{{ f.file.url }}" download>{% trans "Exam" %}</a></li>
             {% endfor %}
             {% for f in s.context %}
-                <li><a href="{{ f.file.url }}" download>Context</a></li>
+                <li><a href="{{ f.file.url }}" download>{% trans "Context" %}</a></li>
             {% endfor %}
             {% for r in s.results %}
-                <li><a href="{{ r.file.url }}" download>{{ r.level }} Result</a></li>
+                <li><a href="{{ r.file.url }}" download>{{ r.level }} {% trans "Result" %}</a></li>
             {% endfor %}
             </ul>
         </li>
     {% empty %}
-        <li class="empty">No sessions found.</li>
+        <li class="empty">{% trans "No sessions found." %}</li>
     {% endfor %}
     </ul>
 </div>

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-10 21:20+0000\n"
+"POT-Creation-Date: 2025-07-10 23:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,41 +17,96 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: KlaSim/settings.py:115
+
+#: KlaSim/settings.py:110
 msgid "English"
 msgstr "Englisch"
 
-#: KlaSim/settings.py:116
+#: KlaSim/settings.py:111
 msgid "Deutsch"
 msgstr "Deutsch"
 
-#: config/forms.py:6
+#: config/forms.py:7
 msgid "Admin password"
 msgstr "Admin-Passwort"
 
-#: config/forms.py:7 config/forms.py:41
+#: config/forms.py:8 config/forms.py:42
 msgid "Simulation password"
 msgstr "Simulations-Passwort"
 
-#: config/forms.py:13 config/forms.py:50
-#: config/templates/config/settings.html:38
+#: config/forms.py:14 config/forms.py:51
+#: config/templates/config/settings.html:27
 msgid "OpenAI API Key"
 msgstr "OpenAI API-Schlüssel"
 
-#: config/forms.py:14 config/forms.py:51
+#: config/forms.py:15 config/forms.py:52
 msgid "Language"
 msgstr "Sprache"
 
-#: config/forms.py:31
+#: config/forms.py:32
 msgid "Password"
 msgstr "Passwort"
 
-#: config/forms.py:36
+#: config/forms.py:37
 msgid "New settings password"
 msgstr "Neues Einstellungs-Passwort"
 
+#: config/templates/config/login.html:7
+#, fuzzy
+#| msgid "Close Settings"
+msgid "Unlock Settings"
+msgstr "Einstellungen entsperren"
+
+#: config/templates/config/login.html:12
+msgid "Enter password to unlock Settings"
+msgstr "Passwort eingeben, um Einstellungen zu entsperren"
+
+#: config/templates/config/login.html:17
+msgid "Unlock"
+msgstr "Entsperren"
+
+#: config/templates/config/sessions.html:7
+#: config/templates/config/sessions.html:13
+#: config/templates/config/settings.html:15
+msgid "Sessions"
+msgstr "Sitzungen"
+
+#: config/templates/config/sessions.html:14
+msgid "Back"
+msgstr "Zurück"
+
+#: config/templates/config/sessions.html:25
+msgid "Delete all sessions?"
+msgstr "Alle Sitzungen löschen?"
+
+#: config/templates/config/sessions.html:25
+msgid "Delete All Sessions"
+msgstr "Alle Sitzungen löschen"
+
+#: config/templates/config/sessions.html:31
+msgid "Download ZIP"
+msgstr "ZIP herunterladen"
+
+#: config/templates/config/sessions.html:34
+msgid "Exam"
+msgstr "Klausur"
+
+#: config/templates/config/sessions.html:37
+msgid "Context"
+msgstr "Kontext"
+
+#: config/templates/config/sessions.html:40
+#: simulator/templates/simulator/index.html:82
+msgid "Result"
+msgstr "Ergebnis"
+
+#: config/templates/config/sessions.html:45
+msgid "No sessions found."
+msgstr "Keine Sitzungen gefunden."
+
 #: config/templates/config/settings.html:7
 #: config/templates/config/settings.html:13
+#: simulator/templates/simulator/index.html:24
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -59,101 +114,159 @@ msgstr "Einstellungen"
 msgid "Close Settings"
 msgstr "Einstellungen schließen"
 
-#: config/templates/config/settings.html:15
-msgid "Sessions"
-msgstr "Sitzungen"
-
-#: config/templates/config/settings.html:39
-#: config/templates/config/settings.html:118
+#: config/templates/config/settings.html:28
+#: config/templates/config/settings.html:107
 msgid "Valid"
 msgstr "Gültig"
 
-#: config/templates/config/settings.html:39
-#: config/templates/config/settings.html:119
+#: config/templates/config/settings.html:28
+#: config/templates/config/settings.html:108
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: config/templates/config/settings.html:41
+#: config/templates/config/settings.html:30
 msgid "Used to access the OpenAI API."
 msgstr "Wird zum Zugriff auf die OpenAI-API verwendet."
 
-#: config/templates/config/settings.html:48
+#: config/templates/config/settings.html:37
 msgid "Set new Settings-Password"
 msgstr "Neues Einstellungs-Passwort setzen"
 
-#: config/templates/config/settings.html:52
+#: config/templates/config/settings.html:41
 msgid "Require Simulation Password"
 msgstr "Simulations-Passwort erforderlich"
 
-#: config/templates/config/settings.html:60
+#: config/templates/config/settings.html:49
 msgid "Protects against unwanted costs in public networks."
 msgstr "Schützt vor unerwünschten Kosten in öffentlichen Netzen."
 
-#: config/templates/config/settings.html:64
+#: config/templates/config/settings.html:53
 #, python-format
 msgid "Prompts (%(language)s)"
 msgstr "Prompts (%(language)s)"
 
-#: config/templates/config/settings.html:68
+#: config/templates/config/settings.html:57
 msgid "System Prompt"
 msgstr "System-Prompt"
 
-#: config/templates/config/settings.html:74
+#: config/templates/config/settings.html:63
 msgid "Base Instruction"
 msgstr "Basisanweisung"
 
-#: config/templates/config/settings.html:80
+#: config/templates/config/settings.html:69
 msgid "Level Low"
 msgstr "Niveau Niedrig"
 
-#: config/templates/config/settings.html:86
+#: config/templates/config/settings.html:75
 msgid "Level Medium"
 msgstr "Niveau Mittel"
 
-#: config/templates/config/settings.html:92
+#: config/templates/config/settings.html:81
 msgid "Level High"
 msgstr "Niveau Hoch"
 
-#: config/templates/config/settings.html:101
+#: config/templates/config/settings.html:90
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: config/templates/config/settings.html:103
+#: config/templates/config/settings.html:92
 msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
-#: config/templates/config/settings.html:106
+#: config/templates/config/settings.html:95
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: config/templates/config/settings.html:107
+#: config/templates/config/settings.html:96
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: config/templates/config/settings.html:120
+#: config/templates/config/settings.html:109
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
-#: config/templates/config/settings.html:121
+#: config/templates/config/settings.html:110
 msgid "Default"
 msgstr "Standard"
 
-#: config/templates/config/settings.html:122
+#: config/templates/config/settings.html:111
 msgid "On"
 msgstr "Ein"
 
-#: config/templates/config/settings.html:123
+#: config/templates/config/settings.html:112
 msgid "Off"
 msgstr "Aus"
 
-#: config/templates/config/settings.html:124
+#: config/templates/config/settings.html:113
 msgid "Passwords do not match"
 msgstr "Passwörter stimmen nicht überein"
 
-#: config/views.py:108
-msgid "Settings saved"
-msgstr "Einstellungen gespeichert"
+#: simulator/templates/simulator/index.html:7
+#: simulator/templates/simulator/index.html:13
+msgid "Exam Simulator"
+msgstr "Klausur-Simulator"
 
-#: config/views.py:179
-msgid "Sessions deleted"
-msgstr "Sitzungen gelöscht"
+#: simulator/templates/simulator/index.html:16
+msgid "Setup"
+msgstr "Setup"
+
+#: simulator/templates/simulator/index.html:18
+msgid "Key Fail"
+msgstr "Key-Fehler"
+
+#: simulator/templates/simulator/index.html:20
+msgid "Active"
+msgstr "Aktiv"
+
+#: simulator/templates/simulator/index.html:37
+msgid "Upload Exam"
+msgstr "Klausur hochladen"
+
+#: simulator/templates/simulator/index.html:42
+#: simulator/templates/simulator/index.html:62
+msgid "Upload"
+msgstr "Upload"
+
+#: simulator/templates/simulator/index.html:48
+msgid "Remove exam"
+msgstr "Klausur entfernen"
+
+#: simulator/templates/simulator/index.html:51
+msgid "No exam uploaded."
+msgstr "Keine Klausur hochgeladen."
+
+#: simulator/templates/simulator/index.html:57
+msgid "Upload Context"
+msgstr "Kontextdatei hochladen"
+
+#: simulator/templates/simulator/index.html:68
+msgid "Remove context"
+msgstr "Kontext entfernen"
+
+#: simulator/templates/simulator/index.html:71
+msgid "No context files uploaded."
+msgstr "Keine Kontextdateien hochgeladen."
+
+#: simulator/templates/simulator/index.html:78
+msgid "Results"
+msgstr "Ergebnisse"
+
+#: simulator/templates/simulator/index.html:93
+msgid "Upload files first"
+msgstr "Erst Dateien hochladen"
+
+#: simulator/templates/simulator/index.html:93
+msgid "Start AI simulation"
+msgstr "KI-Simulation starten"
+
+#: simulator/templates/simulator/index.html:105
+#, fuzzy
+#| msgid "New password"
+msgid "Enter password"
+msgstr "Passwort eingeben"
+
+#~ msgid "Settings saved"
+#~ msgstr "Einstellungen gespeichert"
+
+#~ msgid "Sessions deleted"
+#~ msgstr "Sitzungen gelöscht"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-10 21:20+0000\n"
+"POT-Creation-Date: 2025-07-10 23:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,41 +17,96 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-#: KlaSim/settings.py:115
+
+#: KlaSim/settings.py:110
 msgid "English"
 msgstr "English"
 
-#: KlaSim/settings.py:116
+#: KlaSim/settings.py:111
 msgid "Deutsch"
 msgstr "German"
 
-#: config/forms.py:6
+#: config/forms.py:7
 msgid "Admin password"
 msgstr "Admin password"
 
-#: config/forms.py:7 config/forms.py:41
+#: config/forms.py:8 config/forms.py:42
 msgid "Simulation password"
 msgstr "Simulation password"
 
-#: config/forms.py:13 config/forms.py:50
-#: config/templates/config/settings.html:38
+#: config/forms.py:14 config/forms.py:51
+#: config/templates/config/settings.html:27
 msgid "OpenAI API Key"
 msgstr "OpenAI API Key"
 
-#: config/forms.py:14 config/forms.py:51
+#: config/forms.py:15 config/forms.py:52
 msgid "Language"
 msgstr "Language"
 
-#: config/forms.py:31
+#: config/forms.py:32
 msgid "Password"
 msgstr "Password"
 
-#: config/forms.py:36
+#: config/forms.py:37
 msgid "New settings password"
 msgstr "New settings password"
 
+#: config/templates/config/login.html:7
+#, fuzzy
+#| msgid "Close Settings"
+msgid "Unlock Settings"
+msgstr "Unlock Settings"
+
+#: config/templates/config/login.html:12
+msgid "Enter password to unlock Settings"
+msgstr "Enter password to unlock Settings"
+
+#: config/templates/config/login.html:17
+msgid "Unlock"
+msgstr "Unlock"
+
+#: config/templates/config/sessions.html:7
+#: config/templates/config/sessions.html:13
+#: config/templates/config/settings.html:15
+msgid "Sessions"
+msgstr "Sessions"
+
+#: config/templates/config/sessions.html:14
+msgid "Back"
+msgstr "Back"
+
+#: config/templates/config/sessions.html:25
+msgid "Delete all sessions?"
+msgstr "Delete all sessions?"
+
+#: config/templates/config/sessions.html:25
+msgid "Delete All Sessions"
+msgstr "Delete All Sessions"
+
+#: config/templates/config/sessions.html:31
+msgid "Download ZIP"
+msgstr "Download ZIP"
+
+#: config/templates/config/sessions.html:34
+msgid "Exam"
+msgstr "Exam"
+
+#: config/templates/config/sessions.html:37
+msgid "Context"
+msgstr "Context"
+
+#: config/templates/config/sessions.html:40
+#: simulator/templates/simulator/index.html:82
+msgid "Result"
+msgstr "Result"
+
+#: config/templates/config/sessions.html:45
+msgid "No sessions found."
+msgstr "No sessions found."
+
 #: config/templates/config/settings.html:7
 #: config/templates/config/settings.html:13
+#: simulator/templates/simulator/index.html:24
 msgid "Settings"
 msgstr "Settings"
 
@@ -59,101 +114,159 @@ msgstr "Settings"
 msgid "Close Settings"
 msgstr "Close Settings"
 
-#: config/templates/config/settings.html:15
-msgid "Sessions"
-msgstr "Sessions"
-
-#: config/templates/config/settings.html:39
-#: config/templates/config/settings.html:118
+#: config/templates/config/settings.html:28
+#: config/templates/config/settings.html:107
 msgid "Valid"
 msgstr "Valid"
 
-#: config/templates/config/settings.html:39
-#: config/templates/config/settings.html:119
+#: config/templates/config/settings.html:28
+#: config/templates/config/settings.html:108
 msgid "Invalid"
 msgstr "Invalid"
 
-#: config/templates/config/settings.html:41
+#: config/templates/config/settings.html:30
 msgid "Used to access the OpenAI API."
 msgstr "Used to access the OpenAI API."
 
-#: config/templates/config/settings.html:48
+#: config/templates/config/settings.html:37
 msgid "Set new Settings-Password"
 msgstr "Set new Settings-Password"
 
-#: config/templates/config/settings.html:52
+#: config/templates/config/settings.html:41
 msgid "Require Simulation Password"
 msgstr "Require Simulation Password"
 
-#: config/templates/config/settings.html:60
+#: config/templates/config/settings.html:49
 msgid "Protects against unwanted costs in public networks."
 msgstr "Protects against unwanted costs in public networks."
 
-#: config/templates/config/settings.html:64
+#: config/templates/config/settings.html:53
 #, python-format
 msgid "Prompts (%(language)s)"
 msgstr "Prompts (%(language)s)"
 
-#: config/templates/config/settings.html:68
+#: config/templates/config/settings.html:57
 msgid "System Prompt"
 msgstr "System Prompt"
 
-#: config/templates/config/settings.html:74
+#: config/templates/config/settings.html:63
 msgid "Base Instruction"
 msgstr "Base Instruction"
 
-#: config/templates/config/settings.html:80
+#: config/templates/config/settings.html:69
 msgid "Level Low"
 msgstr "Level Low"
 
-#: config/templates/config/settings.html:86
+#: config/templates/config/settings.html:75
 msgid "Level Medium"
 msgstr "Level Medium"
 
-#: config/templates/config/settings.html:92
+#: config/templates/config/settings.html:81
 msgid "Level High"
 msgstr "Level High"
 
-#: config/templates/config/settings.html:101
+#: config/templates/config/settings.html:90
 msgid "New password"
 msgstr "New password"
 
-#: config/templates/config/settings.html:103
+#: config/templates/config/settings.html:92
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: config/templates/config/settings.html:106
+#: config/templates/config/settings.html:95
 msgid "Cancel"
 msgstr "Cancel"
 
-#: config/templates/config/settings.html:107
+#: config/templates/config/settings.html:96
 msgid "Confirm"
 msgstr "Confirm"
 
-#: config/templates/config/settings.html:120
+#: config/templates/config/settings.html:109
 msgid "Custom"
 msgstr "Custom"
 
-#: config/templates/config/settings.html:121
+#: config/templates/config/settings.html:110
 msgid "Default"
 msgstr "Default"
 
-#: config/templates/config/settings.html:122
+#: config/templates/config/settings.html:111
 msgid "On"
 msgstr "On"
 
-#: config/templates/config/settings.html:123
+#: config/templates/config/settings.html:112
 msgid "Off"
 msgstr "Off"
 
-#: config/templates/config/settings.html:124
+#: config/templates/config/settings.html:113
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
-#: config/views.py:108
-msgid "Settings saved"
-msgstr "Settings saved"
+#: simulator/templates/simulator/index.html:7
+#: simulator/templates/simulator/index.html:13
+msgid "Exam Simulator"
+msgstr "Exam Simulator"
 
-#: config/views.py:179
-msgid "Sessions deleted"
-msgstr "Sessions deleted"
+#: simulator/templates/simulator/index.html:16
+msgid "Setup"
+msgstr "Setup"
+
+#: simulator/templates/simulator/index.html:18
+msgid "Key Fail"
+msgstr "Key Fail"
+
+#: simulator/templates/simulator/index.html:20
+msgid "Active"
+msgstr "Active"
+
+#: simulator/templates/simulator/index.html:37
+msgid "Upload Exam"
+msgstr "Upload Exam"
+
+#: simulator/templates/simulator/index.html:42
+#: simulator/templates/simulator/index.html:62
+msgid "Upload"
+msgstr "Upload"
+
+#: simulator/templates/simulator/index.html:48
+msgid "Remove exam"
+msgstr "Remove exam"
+
+#: simulator/templates/simulator/index.html:51
+msgid "No exam uploaded."
+msgstr "No exam uploaded."
+
+#: simulator/templates/simulator/index.html:57
+msgid "Upload Context"
+msgstr "Upload Context"
+
+#: simulator/templates/simulator/index.html:68
+msgid "Remove context"
+msgstr "Remove context"
+
+#: simulator/templates/simulator/index.html:71
+msgid "No context files uploaded."
+msgstr "No context files uploaded."
+
+#: simulator/templates/simulator/index.html:78
+msgid "Results"
+msgstr "Results"
+
+#: simulator/templates/simulator/index.html:93
+msgid "Upload files first"
+msgstr "Upload files first"
+
+#: simulator/templates/simulator/index.html:93
+msgid "Start AI simulation"
+msgstr "Start AI simulation"
+
+#: simulator/templates/simulator/index.html:105
+#, fuzzy
+#| msgid "New password"
+msgid "Enter password"
+msgstr "Enter password"
+
+#~ msgid "Settings saved"
+#~ msgstr "Settings saved"
+
+#~ msgid "Sessions deleted"
+#~ msgstr "Sessions deleted"

--- a/simulator/templates/simulator/index.html
+++ b/simulator/templates/simulator/index.html
@@ -1,27 +1,27 @@
-{% load static %}
+{% load static i18n %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Klausur-Simulator</title>
+    <title>{% trans "Exam Simulator" %}</title>
     <link rel="stylesheet" href="{% static 'simulator/style.css' %}">
 </head>
 <body>
     <div class="container">
         <header>
-            <h1>Klausur-Simulator
+            <h1>{% trans "Exam Simulator" %}
                 <span class="status-indicator{% if setup_required %} warn{% elif not api_key_valid %} error{% else %} ok{% endif %}">
                     {% if setup_required %}
-                        <a href="{% url 'setup' %}">Setup</a>
+                        <a href="{% url 'setup' %}">{% trans "Setup" %}</a>
                     {% elif not api_key_valid %}
-                        &#9679; Key Fail
+                        &#9679; {% trans "Key Fail" %}
                     {% else %}
-                        &#9679; Aktiv
+                        &#9679; {% trans "Active" %}
                     {% endif %}
                 </span>
             </h1>
-            <a class="settings-link" href="{% url 'settings' %}" title="Settings">&#9881;</a>
+            <a class="settings-link" href="{% url 'settings' %}" title="{% trans 'Settings' %}">&#9881;</a>
         </header>
 
         {% if messages %}
@@ -34,52 +34,52 @@
 
         <main>
             <section class="file-upload exam">
-                <h2><span class="icon">&#128196;</span> Klausur hochladen</h2>
+                <h2><span class="icon">&#128196;</span> {% trans "Upload Exam" %}</h2>
                 <form action="{% url 'upload_exam' %}" method="post" enctype="multipart/form-data">
                     {% csrf_token %}
                     {{ exam_form.file }}
                     {{ exam_form.file.errors }}
-                    <button class="btn upload" type="submit">Upload</button>
+                    <button class="btn upload" type="submit">{% trans "Upload" %}</button>
                 </form>
                 <ul class="file-list">
                 {% for f in exam_files %}
                     <li>
                         <span class="filename">{{ f.file.name|cut:"exam_files/" }}</span>
-                        <a class="btn remove" href="{% url 'delete_exam' f.pk %}" aria-label="Klausur entfernen">&#10006;</a>
+                        <a class="btn remove" href="{% url 'delete_exam' f.pk %}" aria-label="{% trans 'Remove exam' %}">&#10006;</a>
                     </li>
                 {% empty %}
-                    <li class="empty">Keine Klausur hochgeladen.</li>
+                    <li class="empty">{% trans "No exam uploaded." %}</li>
                 {% endfor %}
                 </ul>
             </section>
 
             <section class="file-upload context">
-                <h2><span class="icon">&#128206;</span> Kontextdatei hochladen</h2>
+                <h2><span class="icon">&#128206;</span> {% trans "Upload Context" %}</h2>
                 <form action="{% url 'upload_context' %}" method="post" enctype="multipart/form-data">
                     {% csrf_token %}
                     {{ context_form.file }}
                     {{ context_form.file.errors }}
-                    <button class="btn upload" type="submit">Upload</button>
+                    <button class="btn upload" type="submit">{% trans "Upload" %}</button>
                 </form>
                 <ul class="file-list">
                 {% for f in context_files %}
                     <li>
                         <span class="filename">{{ f.file.name|cut:"context_files/" }}</span>
-                        <a class="btn remove" href="{% url 'delete_context' f.pk %}" aria-label="Kontext entfernen">&#10006;</a>
+                        <a class="btn remove" href="{% url 'delete_context' f.pk %}" aria-label="{% trans 'Remove context' %}">&#10006;</a>
                     </li>
                 {% empty %}
-                    <li class="empty">Keine Kontextdateien hochgeladen.</li>
+                    <li class="empty">{% trans "No context files uploaded." %}</li>
                 {% endfor %}
                 </ul>
             </section>
 
             {% if ai_results %}
             <section class="ai-results">
-                <h2><span class="icon">&#128196;</span> Ergebnisse</h2>
+                <h2><span class="icon">&#128196;</span> {% trans "Results" %}</h2>
                 <ul class="file-list">
                 {% for r in ai_results %}
                     <li>
-                        <a href="{{ r.file.url }}" download>{{ r.level }} Ergebnis</a>
+                        <a href="{{ r.file.url }}" download>{{ r.level }} {% trans "Result" %}</a>
                     </li>
                 {% endfor %}
                 </ul>
@@ -90,7 +90,7 @@
             <form id="runForm" action="{% url 'run_simulation' %}" method="post" style="width:100%;">
                 {% csrf_token %}
                 <input type="hidden" name="sim_password" id="simPwField">
-                <button id="runBtn" class="btn main-action" disabled title="Erst Dateien hochladen">KI-Simulation starten</button>
+                <button id="runBtn" class="btn main-action" disabled title="{% trans 'Upload files first' %}">{% trans 'Start AI simulation' %}</button>
             </form>
         </footer>
     </div>
@@ -102,13 +102,14 @@
         const needPw = {{ sim_password_required|yesno:'true,false' }};
         const hasExam = {{ exam_files|length }} > 0;
         const hasContext = {{ context_files|length }} > 0;
+        const TXT_ENTER_PW = "{{ _('Enter password') }}";
         if (hasExam && hasContext) {
             runBtn.removeAttribute('disabled');
             runBtn.removeAttribute('title');
         }
         runForm?.addEventListener('submit', (e) => {
             if (needPw && !simPwField.value) {
-                const pw = prompt('Passwort eingeben');
+                const pw = prompt(TXT_ENTER_PW);
                 if (pw === null) { e.preventDefault(); return; }
                 simPwField.value = pw;
             }


### PR DESCRIPTION
## Summary
- enable i18n in `login.html`, `sessions.html`, and `index.html`
- regenerate translation catalogs
- add missing English and German translations

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68704e2065cc83248d8a6b5fa5d10d8c